### PR TITLE
fix line_number in jupyter_ascending#execute (because vim starts at 1)

### DIFF
--- a/autoload/jupyter_ascending.vim
+++ b/autoload/jupyter_ascending.vim
@@ -41,8 +41,9 @@ function! jupyter_ascending#execute() abort
         \ "%s -m jupyter_ascending.requests.execute --filename '%s' --linenumber %s",
         \ g:jupyter_ascending_python_executable,
         \ file_name,
-        \ line('.')
+        \ line('.')-1
         \ )
+" -1 because vim starts at 1
 
   call s:execute(command_string)
 endfunction


### PR DESCRIPTION
I noticed a bug when I execute the line just before the next cell (with # %%) and I remember vim line numbering starts at 1 not 0. So this must be a bug right? All ascend python code assumes we start at 0. Thoughts?