### PR TITLE
add support for calling restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Execute all cells
 nmap <space><space>X <Plug>JupyterExecuteAll
 ```
 
+Restart kernel
+```vim
+nmap <space><space>r <Plug>JupyterRestart
+
+```
 NOTE: it syncs your `py` file with `ipynb` file whenever you save your `py` file.
 
 Use `# %%` to separate cells.

--- a/autoload/jupyter_ascending.vim
+++ b/autoload/jupyter_ascending.vim
@@ -62,3 +62,20 @@ function! jupyter_ascending#execute_all() abort
 
   call s:execute(command_string)
 endfunction
+
+
+function! jupyter_ascending#restart() abort
+  let file_name = expand("%:p")
+
+  if match(file_name, g:jupyter_ascending_match_pattern) < 0
+    return
+  endif
+
+  let command_string = printf(
+        \ "%s -m jupyter_ascending.requests.restart --filename '%s'",
+        \ g:jupyter_ascending_python_executable,
+        \ file_name
+        \ )
+
+  call s:execute(command_string)
+endfunction

--- a/plugin/jupyter_ascending.vim
+++ b/plugin/jupyter_ascending.vim
@@ -13,8 +13,11 @@ augroup END
 
 nnoremap <Plug>JupyterExecute    :call jupyter_ascending#execute()<CR>
 nnoremap <Plug>JupyterExecuteAll :call jupyter_ascending#execute_all()<CR>
+nnoremap <Plug>JupyterRestart    :call jupyter_ascending#restart()<CR>
+
 
 if get(g:, 'jupyter_ascending_default_mappings', v:true)
   nmap <space><space>x <Plug>JupyterExecute
   nmap <space><space>X <Plug>JupyterExecuteAll
+  nmap <space><space>r <Plug>JupyterRestart
 endif


### PR DESCRIPTION
Although jupyter_ascending exposes a script to restart the kernel, this was not callable from vim. Add the necessary function and <Plug> definition.